### PR TITLE
Fix to remove selected text using backward key input

### DIFF
--- a/Sources/KeyboardKit/Proxy/UITextDocumentProxy+Delete.swift
+++ b/Sources/KeyboardKit/Proxy/UITextDocumentProxy+Delete.swift
@@ -23,6 +23,11 @@ public extension UITextDocumentProxy {
      Delete backwards a certain range.
      */
     func deleteBackward(_ range: DeleteBackwardRange) {
+        if let selectedText = selectedText {
+            adjustTextPosition(byCharacterOffset: 1)
+            deleteBackward(times: selectedText.count)
+            return
+        }
         guard let text = deleteBackwardText(for: range) else { return }
         deleteBackward(times: text.count)
     }


### PR DESCRIPTION
Hi, @danielsaidi thanks for keyboardKit. I saw the following bug.

I selected part of the text and pressed the backward button, but it was not removed

Fix a bug where the selected text was not removed through the `backward` button
