### PR TITLE
UX improvements

### DIFF
--- a/RELEASE_NOTES.md
+++ b/RELEASE_NOTES.md
@@ -22,6 +22,11 @@ The dark appearance colors have been renamed. The old names are now deprecated.
 * `KeyboardColor` has new colors.
 * `Color+Keyboard` has new colors.
 
+### 🐛 Bug fixes
+
+* `InputCallout` now applies the provided style's callout text color.
+* `SecondaryInputCallout` now uses the provided style's callout text color.
+
 ### 🗑 Deprecations
 
 * Color extensions for the button background colors are now suffixed with `Background`.
@@ -30,7 +35,8 @@ The dark appearance colors have been renamed. The old names are now deprecated.
 
 ### 💥 Breaking changes
 
-* Since `KeyboardColor` is an enum, the dark appearance cases have been renamed to keep things tight. 
+* `KeyboardColor`'s dark appearance cases have been renamed to keep things tight.
+* `SecondaryInputCalloutStyle`'s text color property has been removed. Use the callout style's text color instead.  
 
 
 

--- a/Sources/KeyboardKit/Callouts/InputCallout.swift
+++ b/Sources/KeyboardKit/Callouts/InputCallout.swift
@@ -72,6 +72,7 @@ private extension InputCallout {
         Text(context.input ?? "")
             .font(style.font)
             .frame(width: buttonSize.width + calloutSize.width, height: calloutSize.height)
+            .foregroundColor(calloutStyle.textColor)
             .background(calloutBackground)
             .offset(y: -buttonSize.height)
     }

--- a/Sources/KeyboardKit/Callouts/SecondaryInputCallout.swift
+++ b/Sources/KeyboardKit/Callouts/SecondaryInputCallout.swift
@@ -91,7 +91,7 @@ private extension SecondaryInputCallout {
                 Text($0.element)
                     .frame(buttonSize)
                     .background(isSelected($0.offset) ? style.selectedBackgroundColor : .clear)
-                    .foregroundColor(isSelected($0.offset) ? style.selectedTextColor : style.textColor)
+                    .foregroundColor(isSelected($0.offset) ? style.selectedTextColor : style.callout.textColor)
                     .cornerRadius(cornerRadius)
                     .padding(.vertical, style.verticalPadding)
             }

--- a/Sources/KeyboardKit/Callouts/SecondaryInputCalloutStyle.swift
+++ b/Sources/KeyboardKit/Callouts/SecondaryInputCalloutStyle.swift
@@ -22,13 +22,11 @@ public struct SecondaryInputCalloutStyle {
         font: Font = Self.standardFont,
         selectedBackgroundColor: Color = Color.blue,
         selectedTextColor: Color = Color.white,
-        textColor: Color = .primary,
         verticalPadding: CGFloat = 5) {
         self.callout = callout
         self.font = font
         self.selectedBackgroundColor = selectedBackgroundColor
         self.selectedTextColor = selectedTextColor
-        self.textColor = textColor
         self.verticalPadding = verticalPadding
     }
     
@@ -36,7 +34,6 @@ public struct SecondaryInputCalloutStyle {
     public var font: Font
     public var selectedBackgroundColor: Color
     public var selectedTextColor: Color
-    public var textColor: Color
     public var verticalPadding: CGFloat
 }
 

--- a/Sources/KeyboardKit/Emojis/EmojiCategoryKeyboard.swift
+++ b/Sources/KeyboardKit/Emojis/EmojiCategoryKeyboard.swift
@@ -50,7 +50,7 @@ public struct EmojiCategoryKeyboard: View {
             ScrollView(.horizontal, showsIndicators: false) {
                 keyboardProvider(selection, configuration)
             }
-            EmojiCategoryKeyboardMenu(categories: categories, selection: $selection)
+            EmojiCategoryKeyboardMenu(categories: categories, selection: $selection, configuration: configuration)
         }
         .onAppear(perform: initialize)
         .onDisappear(perform: saveCurrentCategory)

--- a/Sources/KeyboardKit/Emojis/EmojiCategoryKeyboardMenu.swift
+++ b/Sources/KeyboardKit/Emojis/EmojiCategoryKeyboardMenu.swift
@@ -24,16 +24,16 @@ public struct EmojiCategoryKeyboardMenu: View {
     public init(
         categories: [EmojiCategory] = EmojiCategory.all,
         selection: Binding<EmojiCategory>,
-        font: Font = .footnote,
+        configuration: EmojiKeyboardConfiguration,
         selectedColor: Color = Color.black.opacity(0.1)) {
         self.categories = categories.filter { $0.emojis.count > 0 }
         self._selection = selection
-        self.font = font
+        self.configuration = configuration
         self.selectedColor = selectedColor
     }
     
     private let categories: [EmojiCategory]
-    private let font: Font
+    private let configuration: EmojiKeyboardConfiguration
     private let selectedColor: Color
     
     @State private var isInitialized = false
@@ -50,7 +50,8 @@ public struct EmojiCategoryKeyboardMenu: View {
             Spacer()
             backspaceButton
             Spacer()
-        }.font(font)
+        }
+        .font(configuration.categoryFont)
     }
     
     
@@ -63,7 +64,7 @@ public struct EmojiCategoryKeyboardMenu: View {
         return image.keyboardGestures(
             for: action,
             context: context,
-            actionHandler: handler)
+            actionHandler: handler).scaledToFill()
     }
     
     private var keyboardSwitchButton: some View {
@@ -73,7 +74,7 @@ public struct EmojiCategoryKeyboardMenu: View {
         return Text(text).keyboardGestures(
             for: action,
             context: context,
-            actionHandler: handler)
+            actionHandler: handler).scaledToFill()
     }
     
     private var buttonList: some View {
@@ -96,7 +97,7 @@ public struct EmojiCategoryKeyboardMenu: View {
 @available(iOS 14.0, *)
 struct EmojiCategoryKeyboardMenu_Previews: PreviewProvider {
     static var previews: some View {
-        EmojiCategoryKeyboardMenu(selection: .constant(.activities))
+        EmojiCategoryKeyboardMenu(selection: .constant(.activities), configuration: .standardPhonePortrait)
             .keyboardPreview()
     }
 }

--- a/Sources/KeyboardKit/Emojis/EmojiKeyboardConfiguration.swift
+++ b/Sources/KeyboardKit/Emojis/EmojiKeyboardConfiguration.swift
@@ -25,11 +25,13 @@ public struct EmojiKeyboardConfiguration {
     public init(
         itemSize: CGFloat = 40,
         font: Font = .system(size: 33),
+        categoryFont: Font = .system(size: 20),
         rows: Int = 5,
         horizontalSpacing: CGFloat = 10,
         verticalSpacing: CGFloat = 6) {
         self.itemSize = itemSize
         self.font = font
+        self.categoryFont = categoryFont
         self.rows = rows
         self.horizontalSpacing = horizontalSpacing
         self.verticalSpacing = verticalSpacing
@@ -37,6 +39,7 @@ public struct EmojiKeyboardConfiguration {
     
     public let itemSize: CGFloat
     public let font: Font
+    public let categoryFont: Font
     public let rows: Int
     public let horizontalSpacing: CGFloat
     public let verticalSpacing: CGFloat

--- a/Sources/KeyboardKit/Views/AutocompleteToolbar.swift
+++ b/Sources/KeyboardKit/Views/AutocompleteToolbar.swift
@@ -61,9 +61,11 @@ public struct AutocompleteToolbar: View {
     public typealias SeparatorBuilder = (AutocompleteSuggestion) -> AnyView
     
     public var body: some View {
-        HStack {
-            ForEach(items) {
-                self.view(for: $0)
+        if (!items.isEmpty) {
+            HStack {
+                ForEach(items) {
+                    self.view(for: $0)
+                }
             }
         }
     }
@@ -142,6 +144,7 @@ struct AutocompleteToolbar_Previews: PreviewProvider {
             AutocompleteToolbar(suggestions: previewSuggestions).previewBar()
             AutocompleteToolbar(suggestions: previewSuggestions + [additionalSuggestion]).previewBar()
             AutocompleteToolbar(suggestions: previewSuggestions, itemBuilder: previewItem).previewBar()
+            AutocompleteToolbar(suggestions: [], itemBuilder: previewItem).previewBar()
         }
         .padding()
         .keyboardPreview()


### PR DESCRIPTION
1. AutocompleteToolbar should not be shown when an empty suggestions list is passed

| Before  | Afterr |
| ------------- | ------------- |
| <img width="309" alt="Screen Shot 2021-08-31 at 00 19 14" src="https://user-images.githubusercontent.com/1520328/131464811-a00ce840-edea-4454-a2b5-349be0aac676.png"> | <img width="303" alt="Screen Shot 2021-08-31 at 00 19 29" src="https://user-images.githubusercontent.com/1520328/131464824-9432e216-8342-48e2-a39d-ab19f7ea5b22.png">  |


2. Make EmojisCategoryKeyboardMenu items fixed font size instead of dynamic


**Before:**
| Normal  | Extra small | Extra large |
| ------------- | ------------- | ------------- |
| ![Simulator Screen Shot - iPhone 12 Pro - 2021-09-02 at 00 47 43](https://user-images.githubusercontent.com/1520328/131804214-d3049c6d-bd22-4ea4-9c27-a6134808c175.png) | ![Simulator Screen Shot - iPhone 12 Pro - 2021-09-02 at 00 48 07](https://user-images.githubusercontent.com/1520328/131804175-57987bc4-f4e2-4a4d-a901-599453168384.png) | ![Simulator Screen Shot - iPhone 12 Pro - 2021-09-02 at 00 48 23](https://user-images.githubusercontent.com/1520328/131804115-5ac8209d-b56d-4fb4-a249-57a7802e07ff.png) |

**After:**
| Normal  | Extra small | Extra large |
| ------------- | ------------- | ------------- |
| ![Simulator Screen Shot - iPhone 12 Pro - 2021-09-02 at 00 24 46](https://user-images.githubusercontent.com/1520328/131803672-c9fc6137-e095-40ed-8da8-f03214022ec8.png)  | ![Simulator Screen Shot - iPhone 12 Pro - 2021-09-02 at 00 25 06](https://user-images.githubusercontent.com/1520328/131803626-f40b3281-bae2-4dce-80c6-77dd109353e9.png) | ![Simulator Screen Shot - iPhone 12 Pro - 2021-09-02 at 00 24 30](https://user-images.githubusercontent.com/1520328/131803524-4c1fbce5-5d6a-456c-bbdf-ebb162a7f46e.png) |
