### PR TITLE
Remove any views

### DIFF
--- a/Sources/KeyboardKit/Views/System/SystemKeyboard.swift
+++ b/Sources/KeyboardKit/Views/System/SystemKeyboard.swift
@@ -109,7 +109,7 @@ public struct SystemKeyboard<RowItem: View>: View {
 }
 
 public extension SystemKeyboard where RowItem == AnyView {
-    
+
 /**
  Convenience initializer that uses standard buttons.
 
@@ -129,7 +129,7 @@ public extension SystemKeyboard where RowItem == AnyView {
         inputContext: InputCalloutContext?,
         secondaryInputContext: SecondaryInputCalloutContext?,
         width: CGFloat = KeyboardInputViewController.shared.view.frame.width,
-        buttonContent: @escaping ButtonBuilder<AnyView> = { action, appearance, context in
+        buttonBuilder: @escaping ButtonBuilder<AnyView> = { action, appearance, context in
             AnyView(standardButtonBuilder(action: action, appearance: appearance, context: context))
         }) {
         self.init(
@@ -143,7 +143,7 @@ public extension SystemKeyboard where RowItem == AnyView {
             rowItem: { item, keyboardWidth, inputWidth in
                 AnyView(
                     SystemKeyboardButtonRowItem(
-                        content: buttonContent(item.action, appearance, context),
+                        content: buttonBuilder(item.action, appearance, context),
                         item: item,
                         context: context,
                         keyboardWidth: keyboardWidth,
@@ -185,7 +185,7 @@ func standardSystemKeyboard(
         width: width) { item, keyboardWidth, inputWidth in
         // Use standard button builder
         SystemKeyboardButtonRowItem(
-                content: SystemKeyboard<SystemKeyboardActionButtonContent>.standardButtonBuilder(action: item.action, appearance: appearance, context: context),
+                content: defaultButtonBuilder(action: item.action, appearance: appearance, context: context),
                 item: item,
                 context: context,
                 keyboardWidth: keyboardWidth,
@@ -213,7 +213,7 @@ func standardSystemKeyboard<ButtonContent: View>(
     inputContext: InputCalloutContext?,
     secondaryInputContext: SecondaryInputCalloutContext?,
     width: CGFloat = KeyboardInputViewController.shared.view.frame.width,
-    buttonContent: @escaping ButtonBuilder<ButtonContent>) -> some View {
+    buttonBuilder: @escaping ButtonBuilder<ButtonContent>) -> some View {
     SystemKeyboard(
         layout: layout,
         appearance: appearance,
@@ -224,7 +224,7 @@ func standardSystemKeyboard<ButtonContent: View>(
         width: width,
         rowItem: { item, keyboardWidth, inputWidth in
             SystemKeyboardButtonRowItem(
-                content: buttonContent(item.action, appearance, context),
+                content: buttonBuilder(item.action, appearance, context),
                 item: item,
                 context: context,
                 keyboardWidth: keyboardWidth,
@@ -237,25 +237,36 @@ func standardSystemKeyboard<ButtonContent: View>(
 }
 
 public extension SystemKeyboard {
-    
+
     /**
      This is the standard system keyboard button builder that will be used
      when no custom builder is provided to the view.
      */
+    @available(*, deprecated, message: "Use defaultButtonBuilder() instead")
     static func standardButtonBuilder(
+        action: KeyboardAction,
+            appearance: KeyboardAppearance,
+            context: KeyboardContext) -> AnyView {
+        AnyView(defaultButtonBuilder(action: action, appearance: appearance, context: context))
+    }
+
+}
+/**
+ This is the standard `buttonBuilder`, that will be used
+ when no custom builder is provided to the view.
+ */
+func defaultButtonBuilder(
         action: KeyboardAction,
         appearance: KeyboardAppearance,
         context: KeyboardContext) -> SystemKeyboardActionButtonContent {
-        SystemKeyboardActionButtonContent(
+    SystemKeyboardActionButtonContent(
             action: action,
             appearance: appearance,
             context: context
-        )
-    }
+    )
 }
-
 private extension SystemKeyboard {
-    
+
     func rows(for layout: KeyboardLayout) -> some View {
         ForEach(Array(layout.items.enumerated()), id: \.offset) {
             row(for: layout, items: $0.element)

--- a/Sources/KeyboardKit/Views/System/SystemKeyboard.swift
+++ b/Sources/KeyboardKit/Views/System/SystemKeyboard.swift
@@ -236,8 +236,7 @@ func standardSystemKeyboard<ButtonContent: View>(
     )
 }
 
-public extension SystemKeyboard {
-
+public extension SystemKeyboard where RowItem == AnyView {
     /**
      This is the standard system keyboard button builder that will be used
      when no custom builder is provided to the view.


### PR DESCRIPTION
Rebased afa5a2bfe5fd551a0d5d951328c27e75884b3906 to fix demo. I've reverted `standardButtonBuilder` to its old signature (returning `AnyView` and made it deprecated in favor of strongly-typed `defaultButtonBuilder`. Sorry about breaking everything...

Picking up the thread from https://github.com/KeyboardKit/KeyboardKit/pull/357#issuecomment-986607226:
> In this case, I don't think it brings much value, since it basically just creates a context menu that iterates over the items, which basically just is what the context menu does.

I remember my use-case now. I wanted to have two buttons: one for subtype (alphabet/language) and one for keyboard layout (QWERTY/AZERTY), flattening it all to a single locale picker would make a combinatorial explosion.

It's because I wanted to make a math-specific keyboard where the subtypes are different fields of mathematics and common symbols for that field appear as the letters' alt keys, but users also want to differentiate locales. (And I don't want to create a separate keyboard plugin for each subtype.)