### PR TITLE
Make AutocompleteToolbar & SystemKeyboardSpaceButtonContent & EmojiKeyboard generic

### DIFF
--- a/Demo/Keyboard/KeyboardView.swift
+++ b/Demo/Keyboard/KeyboardView.swift
@@ -53,7 +53,9 @@ private extension KeyboardView {
         if #available(iOSApplicationExtension 14.0, *) {
             EmojiCategoryKeyboard(
                 appearance: appearance,
-                context: keyboardContext)
+                context: keyboardContext,
+                keyboardProvider: standardEmojiKeyboard,
+                titleViewProvider: standardEmojiTitleView)
                 .padding(.vertical)
         } else {
             Text("Requires iOS 14 or later")

--- a/Sources/KeyboardKit/Layout/Providers/iPadKeyboardLayoutProvider.swift
+++ b/Sources/KeyboardKit/Layout/Providers/iPadKeyboardLayoutProvider.swift
@@ -84,7 +84,7 @@ open class iPadKeyboardLayoutProvider: SystemKeyboardLayoutProvider {
      
      This is currently pretty messy and should be cleaned up.
      */
-    open func bottomActions(for context: KeyboardContext) -> KeyboardActionRow {
+    open func bottomActions(for context: KeyboardContext) -> KeyboardActions {
         var result = KeyboardActions()
         let needsDictation = context.needsInputModeSwitchKey
         if let action = keyboardSwitchActionForBottomRow(for: context) { result.append(action) }

--- a/Sources/KeyboardKit/Layout/Providers/iPhoneKeyboardLayoutProvider.swift
+++ b/Sources/KeyboardKit/Layout/Providers/iPhoneKeyboardLayoutProvider.swift
@@ -69,7 +69,7 @@ open class iPhoneKeyboardLayoutProvider: SystemKeyboardLayoutProvider {
      
      This is currently pretty messy and should be cleaned up.
      */
-    open func bottomActions(for context: KeyboardContext) -> KeyboardActionRow {
+    open func bottomActions(for context: KeyboardContext) -> KeyboardActions {
         var result = KeyboardActions()
         let portrait = context.screenOrientation.isPortrait
         let needsInputSwitch = context.needsInputModeSwitchKey

--- a/Sources/KeyboardKit/Views/Autocomplete/AutocompleteToolbar.swift
+++ b/Sources/KeyboardKit/Views/Autocomplete/AutocompleteToolbar.swift
@@ -8,6 +8,70 @@
 
 import SwiftUI
 
+
+/**
+ This typealias represents the action block that is used
+ to create autocomplete suggestion views, which are then
+ wrapped in buttons that trigger the `replacementAction`.
+ */
+public typealias SuggestionBuilder<SuggestionView: View> = (AutocompleteSuggestion, Locale, AutocompleteToolbarStyle) -> SuggestionView
+public typealias SuggestionsSeparatorBuilder<SeparatorView: View> = (AutocompleteSuggestion, AutocompleteToolbarStyle) -> SeparatorView
+
+/**
+ This is the default function that will be used to build
+ an item view for the provided `suggestion`.
+ */
+func standardSuggestion(
+        for suggestion: AutocompleteSuggestion,
+        locale: Locale,
+        style: AutocompleteToolbarStyle) -> AutocompleteToolbarItem {
+    AutocompleteToolbarItem(
+            suggestion: suggestion,
+            style: style.item,
+            locale: locale
+    )
+}
+
+/**
+ This is the default function that will be used to build
+ an item separator after the provided `suggestion`.
+ */
+func standardSuggestionsSeparator(
+        for suggestion: AutocompleteSuggestion,
+        style: AutocompleteToolbarStyle) -> AutocompleteToolbarSeparator {
+    AutocompleteToolbarSeparator(style: style.separator)
+}
+
+public extension AutocompleteToolbar where SuggestionView == AnyView, SeparatorView == AnyView {
+
+    /**
+     Create an autocomplete toolbar.
+
+     - Parameters:
+       - suggestions: A list of suggestions to display in the toolbar.
+       - locale: The locale to apply to the toolbar.
+       - style: The style to apply to the toolbar, by default `.standard`.
+       - itemBuilder: An optional, custom item builder. By default, the static `standardItem` will be used.
+       - separatorBuilder: An optional, custom separator builder. By default, the static `standardSeparator` will be used.
+       - replacementAction: An optional, custom replacement action. By default, the static `standardReplacementAction` will be used.
+     */
+    @available(*, deprecated, message: "Use the generic initializers instead.")
+    init(
+            suggestions: [AutocompleteSuggestion],
+            locale: Locale,
+            style: AutocompleteToolbarStyle = .standard,
+            itemBuilder: @escaping ItemBuilder = Self.standardItem,
+            separatorBuilder: @escaping SeparatorBuilder = Self.standardSeparator,
+            replacementAction: @escaping ReplacementAction = Self.standardReplacementAction) {
+        self.items = suggestions.map { BarItem($0) }
+        self.itemBuilder = itemBuilder
+        self.locale = locale
+        self.style = style
+        self.separatorBuilder = separatorBuilder
+        self.replacementAction = replacementAction
+    }
+}
+
 /**
  This view is a horizontal row with autocomplete buttons and
  separator lines between the buttons.
@@ -22,11 +86,10 @@ import SwiftUI
  You should therefore only return views and not buttons when
  you provide a custom `buttonBuilder`.
  */
-public struct AutocompleteToolbar: View {
-    
+public struct AutocompleteToolbar<SuggestionView: View, SeparatorView: View>: View {
     /**
      Create an autocomplete toolbar.
-     
+
      - Parameters:
        - suggestions: A list of suggestions to display in the toolbar.
        - locale: The locale to apply to the toolbar.
@@ -39,8 +102,8 @@ public struct AutocompleteToolbar: View {
         suggestions: [AutocompleteSuggestion],
         locale: Locale,
         style: AutocompleteToolbarStyle = .standard,
-        itemBuilder: @escaping ItemBuilder = Self.standardItem,
-        separatorBuilder: @escaping SeparatorBuilder = Self.standardSeparator,
+        itemBuilder: @escaping SuggestionBuilder<SuggestionView>,
+        separatorBuilder: @escaping SuggestionsSeparatorBuilder<SeparatorView>,
         replacementAction: @escaping ReplacementAction = Self.standardReplacementAction) {
         self.items = suggestions.map { BarItem($0) }
         self.itemBuilder = itemBuilder
@@ -53,9 +116,9 @@ public struct AutocompleteToolbar: View {
     private let items: [BarItem]
     private let locale: Locale
     private let style: AutocompleteToolbarStyle
-    private let itemBuilder: ItemBuilder
+    private let itemBuilder: SuggestionBuilder<SuggestionView>
     private let replacementAction: ReplacementAction
-    private let separatorBuilder: SeparatorBuilder
+    private let separatorBuilder: SuggestionsSeparatorBuilder<SeparatorView>
     
     /**
      This internal struct is used to encapsulate item data.
@@ -69,14 +132,14 @@ public struct AutocompleteToolbar: View {
         public let id = UUID()
         public let suggestion: AutocompleteSuggestion
     }
-    
+
     /**
      This typealias represents the action block that is used
      to create autocomplete suggestion views, which are then
      wrapped in buttons that trigger the `replacementAction`.
      */
-    public typealias ItemBuilder = (AutocompleteSuggestion, Locale, AutocompleteToolbarStyle) -> AnyView
-    
+    @available(*, deprecated, message: "Use the generic initializers instead.")
+    public typealias ItemBuilder = SuggestionBuilder<AnyView>
     /**
      This typealias represents the action block that is used
      to trigger a text replacement when tapping a suggestion.
@@ -87,8 +150,9 @@ public struct AutocompleteToolbar: View {
      This typealias represents the action block that is used
      to create autocomplete suggestion separator views.
      */
-    public typealias SeparatorBuilder = (AutocompleteSuggestion, AutocompleteToolbarStyle) -> AnyView
-    
+    @available(*, deprecated, message: "Use the standardSuggestion instead.")
+    public typealias SeparatorBuilder = SuggestionsSeparatorBuilder<AnyView>
+
     public var body: some View {
         HStack {
             ForEach(items) { item in
@@ -102,43 +166,41 @@ public struct AutocompleteToolbar: View {
 }
 
 public extension AutocompleteToolbar {
-    
-    /**
-     This is the default function that will be used to build
-     an item view for the provided `suggestion`.
-     */
-    static func standardItem(
-        for suggestion: AutocompleteSuggestion,
-        locale: Locale,
-        style: AutocompleteToolbarStyle) -> AnyView {
-        AnyView(AutocompleteToolbarItem(
-            suggestion: suggestion,
-            style: style.item,
-            locale: locale)
-        )
-    }
-    
     /**
      This is the default action that will be used to trigger
      a text replacement when a `suggestion` is tapped.
      */
     static func standardReplacementAction(
-        for suggestion: AutocompleteSuggestion) {
+            for suggestion: AutocompleteSuggestion) {
         let proxy = KeyboardInputViewController.shared.textDocumentProxy
         let actionHandler = KeyboardInputViewController.shared.keyboardActionHandler
         proxy.insertAutocompleteSuggestion(suggestion)
         actionHandler.handle(.tap, on: .character(""))
+    }
+}
+public extension AutocompleteToolbar where SuggestionView == AnyView, SeparatorView == AnyView {
+
+    /**
+     This is the default function that will be used to build
+     an item view for the provided `suggestion`.
+     */
+    @available(*, deprecated, message: "Use the standardSuggestion instead.")
+    static func standardItem(
+        for suggestion: AutocompleteSuggestion,
+        locale: Locale,
+        style: AutocompleteToolbarStyle) -> AnyView {
+        AnyView(standardSuggestion(for: suggestion, locale: locale, style: style))
     }
     
     /**
      This is the default function that will be used to build
      an item separator after the provided `suggestion`.
      */
+    @available(*, deprecated, message: "Use the standardSuggestionsSeparator instead.")
     static func standardSeparator(
         for suggestion: AutocompleteSuggestion,
         style: AutocompleteToolbarStyle) -> AnyView {
-        AnyView(AutocompleteToolbarSeparator(
-            style: style.separator))
+        AnyView(standardSuggestionsSeparator(for: suggestion, style: style))
     }
 }
 
@@ -186,45 +248,53 @@ struct AutocompleteToolbar_Previews: PreviewProvider {
             AutocompleteToolbar(
                 suggestions: previewSuggestions,
                 locale: KeyboardLocale.english.locale,
-                style: .standard).previewBar()
+                style: .standard,
+                itemBuilder: standardSuggestion,
+                separatorBuilder: standardSuggestionsSeparator
+            ).previewBar()
             AutocompleteToolbar(
                 suggestions: previewSuggestions + [additionalSuggestion],
                 locale: KeyboardLocale.spanish.locale,
-                style: .standard).previewBar()
+                style: .standard,
+                itemBuilder: standardSuggestion,
+                separatorBuilder: standardSuggestionsSeparator).previewBar()
             AutocompleteToolbar(
                 suggestions: previewSuggestions + [additionalSuggestion],
                 locale: KeyboardLocale.spanish.locale,
-                style: .preview1).previewBar()
+                style: .preview1,
+                itemBuilder: standardSuggestion,
+                separatorBuilder: standardSuggestionsSeparator).previewBar()
             AutocompleteToolbar(
                 suggestions: previewSuggestions + [additionalSuggestion],
                 locale: KeyboardLocale.spanish.locale,
-                style: .preview2).previewBar()
+                style: .preview2,
+                itemBuilder: standardSuggestion,
+                separatorBuilder: standardSuggestionsSeparator).previewBar()
             AutocompleteToolbar(
                 suggestions: previewSuggestions,
                 locale: KeyboardLocale.swedish.locale,
                 style: .standard,
-                itemBuilder: previewItem).previewBar()
+                itemBuilder: previewItem,
+                separatorBuilder: standardSuggestionsSeparator).previewBar()
         }
         .padding()
     }
     
-    static func previewItem(for suggestion: AutocompleteSuggestion, locale: Locale, style: AutocompleteToolbarStyle) -> AnyView {
-        AnyView(
-            HStack {
-                Spacer()
-                VStack(spacing: 4) {
-                    AutocompleteToolbarItemTitle(
-                        suggestion: suggestion,
-                        style: style.item,
-                        locale: KeyboardLocale.swedish.locale)
-                        .font(Font.body.bold())
-                    if let subtitle = suggestion.subtitle {
-                        Text(subtitle).font(.footnote)
-                    }
+    static func previewItem(for suggestion: AutocompleteSuggestion, locale: Locale, style: AutocompleteToolbarStyle) -> some View {
+        HStack {
+            Spacer()
+            VStack(spacing: 4) {
+                AutocompleteToolbarItemTitle(
+                    suggestion: suggestion,
+                    style: style.item,
+                    locale: KeyboardLocale.swedish.locale)
+                    .font(Font.body.bold())
+                if let subtitle = suggestion.subtitle {
+                    Text(subtitle).font(.footnote)
                 }
-                Spacer()
             }
-        )
+            Spacer()
+        }
     }
     
     static let previewSuggestions: [AutocompleteSuggestion] = [

--- a/Sources/KeyboardKit/Views/Autocomplete/AutocompleteToolbar.swift
+++ b/Sources/KeyboardKit/Views/Autocomplete/AutocompleteToolbar.swift
@@ -21,7 +21,7 @@ public typealias SuggestionsSeparatorBuilder<SeparatorView: View> = (Autocomplet
  This is the default function that will be used to build
  an item view for the provided `suggestion`.
  */
-func standardSuggestion(
+public func standardSuggestion(
         for suggestion: AutocompleteSuggestion,
         locale: Locale,
         style: AutocompleteToolbarStyle) -> AutocompleteToolbarItem {
@@ -36,7 +36,7 @@ func standardSuggestion(
  This is the default function that will be used to build
  an item separator after the provided `suggestion`.
  */
-func standardSuggestionsSeparator(
+public func standardSuggestionsSeparator(
         for suggestion: AutocompleteSuggestion,
         style: AutocompleteToolbarStyle) -> AutocompleteToolbarSeparator {
     AutocompleteToolbarSeparator(style: style.separator)

--- a/Sources/KeyboardKit/Views/Autocomplete/AutocompleteToolbarItem.swift
+++ b/Sources/KeyboardKit/Views/Autocomplete/AutocompleteToolbarItem.swift
@@ -83,7 +83,9 @@ struct AutocompleteToolbarItem_Previews: PreviewProvider {
             AutocompleteToolbar(
                 suggestions: previewSuggestions,
                 locale: locale,
-                style: .standard)
+                style: .standard,
+                itemBuilder: standardSuggestion,
+                separatorBuilder: standardSuggestionsSeparator)
                 // style: .preview1)
             .previewBar()
         }

--- a/Sources/KeyboardKit/Views/Emojis/EmojiCategoryKeyboard.swift
+++ b/Sources/KeyboardKit/Views/Emojis/EmojiCategoryKeyboard.swift
@@ -18,7 +18,7 @@ public typealias EmojiKeyboardProvider<EmojiKeyboard: View> = (EmojiCategory, Em
 public typealias EmojiTitleProvider<EmojiTitle: View> = (EmojiCategory, String) -> EmojiTitle
 
 @available(iOS 14.0, *)
-func standardEmojiTitleView(for category: EmojiCategory, title: String) -> some View {
+public func standardEmojiTitleView(for category: EmojiCategory, title: String) -> some View {
    HStack {
        Text(title).font(.footnote).bold().textCase(.uppercase).opacity(0.4)
        Spacer()

--- a/Sources/KeyboardKit/Views/Emojis/EmojiCategoryKeyboard.swift
+++ b/Sources/KeyboardKit/Views/Emojis/EmojiCategoryKeyboard.swift
@@ -8,17 +8,47 @@
 
 import SwiftUI
 
-/**
- This keyboard lists all emojis from a selected category, as
- well as a menu that lets the user select a new category and
- change back to an alphabetic keyboard.
- 
- As long as the view requires iOS 14, the extensions must be
- kept in the main struct body for the previews to compile.
- */
 @available(iOS 14.0, *)
-public struct EmojiCategoryKeyboard: View {
-    
+public typealias TitleProvider = (EmojiCategory) -> String
+
+@available(iOS 14.0, *)
+public typealias EmojiKeyboardProvider<EmojiKeyboard: View> = (EmojiCategory, EmojiKeyboardStyle) -> EmojiKeyboard
+
+@available(iOS 14.0, *)
+public typealias EmojiTitleProvider<EmojiTitle: View> = (EmojiCategory, String) -> EmojiTitle
+
+@available(iOS 14.0, *)
+func standardEmojiTitleView(for category: EmojiCategory, title: String) -> some View {
+   HStack {
+       Text(title).font(.footnote).bold().textCase(.uppercase).opacity(0.4)
+       Spacer()
+   }.padding(.horizontal)
+}
+
+@available(iOS 14.0, *)
+public func standardEmojiKeyboard(for category: EmojiCategory, style: EmojiKeyboardStyle) -> some View {
+        EmojiKeyboard(
+            emojis: category.emojis,
+            style: style,
+            emojiButtonBuilder: standardEmojiButton)
+            .padding(.horizontal)
+}
+
+@available(iOS 14.0, *)
+public extension EmojiCategoryKeyboard where KeyboardView == AnyView {
+    @available(*, deprecated, message: "Use the generic initializers instead.")
+    typealias KeyboardProvider = EmojiKeyboardProvider<AnyView>
+}
+
+@available(iOS 14.0, *)
+public extension EmojiCategoryKeyboard where TitleView == AnyView {
+    @available(*, deprecated, message: "Use the generic initializers instead.")
+    typealias TitleViewProvider = EmojiTitleProvider<AnyView>
+}
+
+
+@available(iOS 14.0, *)
+public extension EmojiCategoryKeyboard where KeyboardView == AnyView, TitleView == AnyView {
     /**
      Create an emoji category keyboard.
      
@@ -33,7 +63,8 @@ public struct EmojiCategoryKeyboard: View {
        - titleProvider: A title provider, by default `.standardTitle`.
        - titleViewProvider: A title view provider, by default `.standardTitleView`.
      */
-    public init(
+    @available(*, deprecated, message: "Use the generic initializers instead.")
+    init(
         categories: [EmojiCategory] = EmojiCategory.all,
         appearance: KeyboardAppearance,
         context: KeyboardContext,
@@ -51,23 +82,69 @@ public struct EmojiCategoryKeyboard: View {
         self.titleProvider = titleProvider
         self.titleViewProvider = titleViewProvider
     }
-    
-    public typealias KeyboardProvider = (EmojiCategory, EmojiKeyboardStyle) -> AnyView
-    public typealias TitleProvider = (EmojiCategory) -> String
-    public typealias TitleViewProvider = (EmojiCategory, String) -> AnyView
+    @available(*, deprecated, message: "Use standardEmojiTitleView instead.")
+    static func standardTitleView(for category: EmojiCategory, title: String) -> AnyView {
+        AnyView(standardEmojiTitleView(for: category, title: title))
+    }
+    @available(*, deprecated, message: "Use standardEmojiKeyboard instead.")
+    static func standardKeyboard(for category: EmojiCategory, style: EmojiKeyboardStyle) -> AnyView {
+        AnyView(standardEmojiKeyboard(for: category, style: style))
+    }
+}
+/**
+ This keyboard lists all emojis from a selected category, as
+ well as a menu that lets the user select a new category and
+ change back to an alphabetic keyboard.
+ 
+ As long as the view requires iOS 14, the extensions must be
+ kept in the main struct body for the previews to compile.
+ */
+@available(iOS 14.0, *)
+public struct EmojiCategoryKeyboard<KeyboardView: View, TitleView: View>: View {
     
     private let initialSelection: EmojiCategory?
     private let categories: [EmojiCategory]
     private let appearance: KeyboardAppearance
     private let context: KeyboardContext
     private let style: EmojiKeyboardStyle
-    private let keyboardProvider: KeyboardProvider
+    private let keyboardProvider: EmojiKeyboardProvider<KeyboardView>
     private let titleProvider: TitleProvider
-    private let titleViewProvider: TitleViewProvider
+    private let titleViewProvider: EmojiTitleProvider<TitleView>
     
     @State private var isInitialized = false
     @State private var selection = EmojiCategory.smileys
-    
+    /**
+     Create an emoji category keyboard.
+     
+     - Parameters:
+       - categories: The categories to include in the menu.
+       - appearance: The appearance to apply to the menu.
+       - context: The context to bind the buttons to.
+       - selection: The current selection.
+       - style: The style to apply to the keyboard, by default `.standardPhonePortrait`.
+       - selectedColor: The color of the selected category.
+       - keyboardProvider: A keyboard provider, by default `.standardKeyboard`.
+       - titleProvider: A title provider, by default `.standardTitle`.
+       - titleViewProvider: A title view provider, by default `.standardTitleView`.
+     */
+    init(
+        categories: [EmojiCategory] = EmojiCategory.all,
+        appearance: KeyboardAppearance,
+        context: KeyboardContext,
+        selection: EmojiCategory? = nil,
+        style: EmojiKeyboardStyle = .standardPhonePortrait,
+        keyboardProvider: @escaping EmojiKeyboardProvider<KeyboardView>,
+        titleProvider: @escaping TitleProvider = Self.standardTitle,
+        titleViewProvider: @escaping EmojiTitleProvider<TitleView>) {
+        self.categories = categories.filter { $0.emojis.count > 0 }
+        self.appearance = appearance
+        self.style = style
+        self.context = context
+        self.initialSelection = selection
+        self.keyboardProvider = keyboardProvider
+        self.titleProvider = titleProvider
+        self.titleViewProvider = titleViewProvider
+    }
     public var body: some View {
         VStack(spacing: 0) {
             titleViewProvider(selection, titleProvider(selection))
@@ -88,24 +165,9 @@ public struct EmojiCategoryKeyboard: View {
     
     // MARK: - Public Static Builders
     
-    public static func standardKeyboard(for category: EmojiCategory, style: EmojiKeyboardStyle) -> AnyView {
-        AnyView(
-            EmojiKeyboard(
-                emojis: category.emojis,
-                style: style)
-                .padding(.horizontal)
-        )
-    }
     
     public static func standardTitle(for category: EmojiCategory) -> String {
         category.title
-    }
-    
-    public static func standardTitleView(for category: EmojiCategory, title: String) -> AnyView {
-        AnyView(HStack {
-            Text(title).font(.footnote).bold().textCase(.uppercase).opacity(0.4)
-            Spacer()
-        }.padding(.horizontal))
     }
     
 
@@ -137,6 +199,9 @@ struct EmojiCategoryMenu_Keyboard: PreviewProvider {
         EmojiCategoryKeyboard(
             appearance: .preview,
             context: .preview,
-            selection: .smileys)
+            selection: .smileys,
+            keyboardProvider: standardEmojiKeyboard,
+            titleViewProvider: standardEmojiTitleView
+        )
     }
 }

--- a/Sources/KeyboardKit/Views/Emojis/EmojiCategoryKeyboard.swift
+++ b/Sources/KeyboardKit/Views/Emojis/EmojiCategoryKeyboard.swift
@@ -127,7 +127,7 @@ public struct EmojiCategoryKeyboard<KeyboardView: View, TitleView: View>: View {
        - titleProvider: A title provider, by default `.standardTitle`.
        - titleViewProvider: A title view provider, by default `.standardTitleView`.
      */
-    init(
+    public init(
         categories: [EmojiCategory] = EmojiCategory.all,
         appearance: KeyboardAppearance,
         context: KeyboardContext,

--- a/Sources/KeyboardKit/Views/Emojis/EmojiKeyboard.swift
+++ b/Sources/KeyboardKit/Views/Emojis/EmojiKeyboard.swift
@@ -8,48 +8,84 @@
 
 import SwiftUI
 
-/**
- This view can be used to list an emoji collection using the
- provided configuration.
- 
- You can customize the buttons in the grid by using a custom
- `buttonBuilder` in the initalizer. If you do not, init will
- use the static `standardButton` function.
- */
-@available(iOS 14.0, *)
-public struct EmojiKeyboard: View {
-    
+public extension EmojiKeyboard where EmojiButton == AnyView {
+    @available(*, deprecated, message: "Use the new generic initializers instead.")
+    public typealias ButtonBuilder = EmojiButtonBuilder<AnyView>
+
     /**
      Create an emoji keyboard.
-     
+
      - Parameters:
        - emojis: The emojis to include in the menu.
        - style: The style to apply to the keyboard, by default `.standardPhonePortrait`.
        - buttonBuilder: A emoji keyboard button builder, by default `.standardButton`.
      */
+    @available(*, deprecated, message: "Use the new generic initializers instead.")
     public init(
-        emojis: [Emoji],
-        style: EmojiKeyboardStyle = .standardPhonePortrait,
-        buttonBuilder: @escaping ButtonBuilder = Self.standardButton) {
+            emojis: [Emoji],
+            style: EmojiKeyboardStyle = .standardPhonePortrait,
+            buttonBuilder: @escaping ButtonBuilder = Self.standardButton) {
         let item = GridItem(.fixed(style.itemSize), spacing: style.verticalSpacing - 9)
         self.emojis = emojis.map { EmojiKeyboardItem(emoji: $0) }
         self.style = style
         self.rows = Array(repeating: item, count: style.rows)
         self.buttonBuilder = buttonBuilder
     }
-    
-    public typealias ButtonBuilder = (Emoji, EmojiKeyboardStyle) -> AnyView
-    
+    /**
+     This standard button builder will return an button that
+     applies the keyboard actions of an `.emoji` action.
+     */
+    @available(*, deprecated, message: "Use standardEmojiButton.")
+    public static func standardButton(for emoji: Emoji, configuration: EmojiKeyboardStyle) -> AnyView {
+        AnyView(standardEmojiButton(for: emoji, configuration: configuration))
+    }
+}
+
+public typealias EmojiButtonBuilder<EmojiButton: View> = (Emoji, EmojiKeyboardStyle) -> EmojiButton
+
+/**
+ This view can be used to list an emoji collection using the
+ provided configuration.
+
+ You can customize the buttons in the grid by using a custom
+ `buttonBuilder` in the initalizer. If you do not, init will
+ use the static `standardButton` function.
+ */
+@available(iOS 14.0, *)
+public struct EmojiKeyboard<EmojiButton: View>: View {
+
+    /**
+     Create an emoji keyboard.
+
+     - Parameters:
+       - emojis: The emojis to include in the menu.
+       - style: The style to apply to the keyboard, by default `.standardPhonePortrait`.
+       - emojiButtonBuilder: A emoji keyboard button builder, by default `.standardEmojiButton`.
+     */
+    public init(
+            emojis: [Emoji],
+            style: EmojiKeyboardStyle = .standardPhonePortrait,
+            emojiButtonBuilder: @escaping EmojiButtonBuilder<EmojiButton> = Self.standardEmojiButton
+    ) {
+        let item = GridItem(.fixed(style.itemSize), spacing: style.verticalSpacing - 9)
+        self.emojis = emojis.map {
+            EmojiKeyboardItem(emoji: $0)
+        }
+        self.style = style
+        self.rows = Array(repeating: item, count: style.rows)
+        self.buttonBuilder = buttonBuilder
+    }
+
     struct EmojiKeyboardItem: Identifiable {
         let id = UUID()
         let emoji: Emoji
     }
-    
-    private let buttonBuilder: ButtonBuilder
+
+    private let buttonBuilder: EmojoiButtonBuilder<EmojiButton>
     private let style: EmojiKeyboardStyle
     private let emojis: [EmojiKeyboardItem]
     private let rows: [GridItem]
-        
+
     public var body: some View {
         LazyHGrid(rows: rows, spacing: style.horizontalSpacing) {
             ForEach(emojis) {
@@ -57,21 +93,23 @@ public struct EmojiKeyboard: View {
             }
         }.frame(height: style.totalHeight)
     }
-    
-    
+
+
     // MARK: - Public Extensions (here to make preview work)
-    
+
     /**
      This standard button builder will return an button that
      applies the keyboard actions of an `.emoji` action.
      */
-    public static func standardButton(for emoji: Emoji, configuration: EmojiKeyboardStyle) -> AnyView {
+    public static func standardEmojiButton(for emoji: Emoji, configuration: EmojiKeyboardStyle) -> some View {
         let handler = KeyboardInputViewController.shared.keyboardActionHandler
-        let action = { handler.handle(.tap, on: .emoji(emoji)) }
-        return AnyView(Button(action: action) {
+        let action = {
+            handler.handle(.tap, on: .emoji(emoji))
+        }
+        return Button(action: action) {
             Text(emoji.char)
-                .font(configuration.font)
-        })
+                    .font(configuration.font)
+        }
     }
 }
 

--- a/Sources/KeyboardKit/Views/Emojis/EmojiKeyboard.swift
+++ b/Sources/KeyboardKit/Views/Emojis/EmojiKeyboard.swift
@@ -8,9 +8,10 @@
 
 import SwiftUI
 
+@available(iOS 14.0, *)
 public extension EmojiKeyboard where EmojiButton == AnyView {
     @available(*, deprecated, message: "Use the new generic initializers instead.")
-    public typealias ButtonBuilder = EmojiButtonBuilder<AnyView>
+    typealias ButtonBuilder = EmojiButtonBuilder<AnyView>
 
     /**
      Create an emoji keyboard.
@@ -21,7 +22,7 @@ public extension EmojiKeyboard where EmojiButton == AnyView {
        - buttonBuilder: A emoji keyboard button builder, by default `.standardButton`.
      */
     @available(*, deprecated, message: "Use the new generic initializers instead.")
-    public init(
+    init(
             emojis: [Emoji],
             style: EmojiKeyboardStyle = .standardPhonePortrait,
             buttonBuilder: @escaping ButtonBuilder = Self.standardButton) {
@@ -36,12 +37,18 @@ public extension EmojiKeyboard where EmojiButton == AnyView {
      applies the keyboard actions of an `.emoji` action.
      */
     @available(*, deprecated, message: "Use standardEmojiButton.")
-    public static func standardButton(for emoji: Emoji, configuration: EmojiKeyboardStyle) -> AnyView {
+    static func standardButton(for emoji: Emoji, configuration: EmojiKeyboardStyle) -> AnyView {
         AnyView(standardEmojiButton(for: emoji, configuration: configuration))
     }
 }
 
 public typealias EmojiButtonBuilder<EmojiButton: View> = (Emoji, EmojiKeyboardStyle) -> EmojiButton
+
+@available(iOS 14.0, *)
+func standardEmojiKeyboard(emojis: [Emoji],
+                           style: EmojiKeyboardStyle = .standardPhonePortrait) -> some View {
+    EmojiKeyboard(emojis: emojis, style: style, emojiButtonBuilder: standardEmojiButton)
+}
 
 /**
  This view can be used to list an emoji collection using the
@@ -65,7 +72,7 @@ public struct EmojiKeyboard<EmojiButton: View>: View {
     public init(
             emojis: [Emoji],
             style: EmojiKeyboardStyle = .standardPhonePortrait,
-            emojiButtonBuilder: @escaping EmojiButtonBuilder<EmojiButton> = Self.standardEmojiButton
+            emojiButtonBuilder: @escaping EmojiButtonBuilder<EmojiButton>
     ) {
         let item = GridItem(.fixed(style.itemSize), spacing: style.verticalSpacing - 9)
         self.emojis = emojis.map {
@@ -73,7 +80,7 @@ public struct EmojiKeyboard<EmojiButton: View>: View {
         }
         self.style = style
         self.rows = Array(repeating: item, count: style.rows)
-        self.buttonBuilder = buttonBuilder
+        self.buttonBuilder = emojiButtonBuilder
     }
 
     struct EmojiKeyboardItem: Identifiable {
@@ -81,7 +88,7 @@ public struct EmojiKeyboard<EmojiButton: View>: View {
         let emoji: Emoji
     }
 
-    private let buttonBuilder: EmojoiButtonBuilder<EmojiButton>
+    private let buttonBuilder: EmojiButtonBuilder<EmojiButton>
     private let style: EmojiKeyboardStyle
     private let emojis: [EmojiKeyboardItem]
     private let rows: [GridItem]
@@ -94,22 +101,20 @@ public struct EmojiKeyboard<EmojiButton: View>: View {
         }.frame(height: style.totalHeight)
     }
 
-
     // MARK: - Public Extensions (here to make preview work)
 
-    /**
-     This standard button builder will return an button that
-     applies the keyboard actions of an `.emoji` action.
-     */
-    public static func standardEmojiButton(for emoji: Emoji, configuration: EmojiKeyboardStyle) -> some View {
-        let handler = KeyboardInputViewController.shared.keyboardActionHandler
-        let action = {
-            handler.handle(.tap, on: .emoji(emoji))
-        }
-        return Button(action: action) {
-            Text(emoji.char)
-                    .font(configuration.font)
-        }
+}
+/**
+ This standard button builder will return an button that
+ applies the keyboard actions of an `.emoji` action.
+ */
+public func standardEmojiButton(for emoji: Emoji, configuration: EmojiKeyboardStyle) -> some View {
+    let handler = KeyboardInputViewController.shared.keyboardActionHandler
+    let action = {
+        handler.handle(.tap, on: .emoji(emoji))
+    }
+    return Button(action: action) {
+        Text(emoji.char).font(configuration.font)
     }
 }
 
@@ -117,7 +122,10 @@ public struct EmojiKeyboard<EmojiButton: View>: View {
 struct EmojiKeyboard_Previews: PreviewProvider {
     static var previews: some View {
         ScrollView(.horizontal) {
-            EmojiKeyboard(emojis: Array(Emoji.all.prefix(50)))
+            EmojiKeyboard(
+                emojis: Array(Emoji.all.prefix(50)),
+                emojiButtonBuilder: standardEmojiButton
+            )
         }
     }
 }

--- a/Sources/KeyboardKit/Views/System/SystemKeyboardSpaceButtonContent.swift
+++ b/Sources/KeyboardKit/Views/System/SystemKeyboardSpaceButtonContent.swift
@@ -59,11 +59,11 @@ private struct StaticSpaceProperties {
 
 private extension SystemKeyboardSpaceButtonContent {
     
-    func text(_ text: String) -> some View {
+    func text(_ text: String) -> SystemKeyboardButtonText {
         SystemKeyboardButtonText(text: text, action: .space)
     }
     
-    var localeView: some View {
+    var localeView: SystemKeyboardButtonText {
         text(localeText)
     }
     

--- a/Sources/KeyboardKit/Views/System/SystemKeyboardSpaceButtonContent.swift
+++ b/Sources/KeyboardKit/Views/System/SystemKeyboardSpaceButtonContent.swift
@@ -18,22 +18,8 @@ import SwiftUI
  are applied later, e.g. the `SystemKeyboard`. If you want a
  complete space button, use `SystemKeyboardSpaceButton`.
  */
-public struct SystemKeyboardSpaceButtonContent: View {
-    
-    /**
-     Create a system keyboard space button content view.
-     
-     - Parameters:
-       - localeText: The display name of the current locale.
-       - spaceText: The localized name for "space".
-     */
-    public init(
-        localeText: String,
-        spaceText: String) {
-        self.localeText = localeText
-        self.spaceText = spaceText
-        self.spaceView = nil
-    }
+public struct SystemKeyboardSpaceButtonContent<SpaceView: View>: View {
+
     
     /**
      Create a system keyboard space button content view.
@@ -42,19 +28,17 @@ public struct SystemKeyboardSpaceButtonContent: View {
        - localeText: The display name of the current locale.
        - spaceView: The custom view to use in the space button.
      */
-    public init<SpaceView: View>(
+    public init(
         localeText: String,
         spaceView: SpaceView) {
         self.localeText = localeText
         self.spaceText = ""
-        self.spaceView = AnyView(spaceView)
+        self.spaceView = spaceView
     }
     
     private let localeText: String
     private let spaceText: String
-    private let spaceView: AnyView?
-    
-    private static var lastLocaleText: String?
+    private let spaceView: SpaceView?
     
     @State private var showLocale = true
     
@@ -66,6 +50,11 @@ public struct SystemKeyboardSpaceButtonContent: View {
         .transition(.opacity)
         .onAppear(perform: performAnimation)
     }
+}
+
+private struct StaticSpaceProperties {
+    // TODO replace/remove static property?
+    static var lastLocaleText: String?
 }
 
 private extension SystemKeyboardSpaceButtonContent {
@@ -88,16 +77,31 @@ private extension SystemKeyboardSpaceButtonContent {
     }
 }
 
+public extension SystemKeyboardSpaceButtonContent where SpaceView == AnyView {
+    /**
+     Create a system keyboard space button content view.
+
+     - Parameters:
+       - localeText: The display name of the current locale.
+       - spaceText: The localized name for "space".
+     */
+    init(localeText: String, spaceText: String) {
+        self.localeText = localeText
+        self.spaceText = spaceText
+        self.spaceView = nil
+    }
+}
+
 private extension SystemKeyboardSpaceButtonContent {
     
     var isNewLocale: Bool {
-        localeText != Self.lastLocaleText
+        localeText != StaticSpaceProperties.lastLocaleText
     }
     
     func performAnimation() {
         showLocale = isNewLocale
         guard isNewLocale else { return }
-        Self.lastLocaleText = localeText
+        StaticSpaceProperties.lastLocaleText = localeText
         DispatchQueue.main.asyncAfter(deadline: .now() + 1) {
             withAnimation { showLocale = false }
         }


### PR DESCRIPTION
These edits were a bit easier than the effort to make `KeyboardView` generic. I've deprecated the old `AnyView` initializers, verified it still works with the demo project.

You probably want to look at the exact location of the utility functions, I just put them in the same file pretty ad-hoq.