### PR TITLE
Support for embedding as UIInputViewController directly in app

### DIFF
--- a/Sources/KeyboardKit/KeyboardInputViewController.swift
+++ b/Sources/KeyboardKit/KeyboardInputViewController.swift
@@ -104,10 +104,16 @@ open class KeyboardInputViewController: UIInputViewController {
     
     /**
      Get the bundle id of the currently active app, that was
-     used to initialize the keyboard extension.
+     used to initialize the keyboard extension, or if the view
+	 is instantiated directly within a host app, the bundle id
+	 of the main bundle
      */
     public var activeAppBundleId: String? {
-        parent?.value(forKey: "_hostBundleID") as? String
+		if Bundle.main.bundlePath.hasSuffix(".appex") {
+			return parent?.value(forKey: "_hostBundleID") as? String
+		} else {
+			return Bundle.main.bundleIdentifier
+		}
     }
     
     /**


### PR DESCRIPTION
This mostly worked, but I had to protect against an undefined key error when instantiating the KeyboardInputViewController in an app, where the parent will not implement the private _hostBundleID property.