### PR TITLE
Protect against negative and infinite dimensions in SwiftUI

### DIFF
--- a/Sources/KeyboardKit/KeyboardInputViewController.swift
+++ b/Sources/KeyboardKit/KeyboardInputViewController.swift
@@ -21,6 +21,13 @@ open class KeyboardInputViewController: UIInputViewController {
     
     open override func viewDidLoad() {
         super.viewDidLoad()
+
+		/// Start with a default width that is non-zero to avoid bad math in SwiftUI if the
+		/// shared KeyboardInputViewController's view is not yet sized to anything appropriate
+		/// to the current screen. This is most likely to happen in a situatoin where the input
+		/// view controller is being instatiated within the context of a host app.
+		self.view.frame.size.width = UIScreen.main.bounds.width
+
         Self.shared = self
         setupLocaleObservation()
         viewWillSetupKeyboard()


### PR DESCRIPTION
When a KeyboardInputViewController is instantiated outside the context of a keyboard extension (i.e. in the host app), it would end up with a zero width and thus lead to computed values for other views in Swift UI that included negative and infinite widths. This lead to various problems including poor layout and in some instances, for example, crashing Xcode's view debugger. Establishing a default width to match the main screen's width seems like a reasonably good default to procted against this problem until the view can be properly sized by the client to match whatever scenario it's intended for.