### PR TITLE
Use minimumDuration.

### DIFF
--- a/Sources/KeyboardKit/Gestures/KeyboardGestures.swift
+++ b/Sources/KeyboardKit/Gestures/KeyboardGestures.swift
@@ -130,17 +130,23 @@ private extension KeyboardGestures {
     
     /**
      This is a plain long press gesure.
+     minimumDuration:  The minimum duration of the long press that must elapse before the gesture succeeds.
+     maximumDistance: The maximum distance that the fingers or cursor performing the long press can move before the gesture fails.
      */
     var longPressGesture: some Gesture {
-        LongPressGesture()
+        
+        LongPressGesture(minimumDuration: 0.25, maximumDistance: 10)
             .onEnded { _ in handleLongPressGesture() }
     }
     
     /**
      This is a drag gesture that starts after a long press.
+     minimumDuration:  The minimum duration of the long press that must elapse before the gesture succeeds.
+     maximumDistance: The maximum distance that the fingers or cursor performing the long press can move before the gesture fails.
      */
     func longPressDragGesture(for geo: GeometryProxy) -> some Gesture {
-        LongPressGesture()
+        
+        LongPressGesture(minimumDuration: 0.25, maximumDistance: 10)
             .onEnded { _ in beginActionCallout(for: geo) }
             .sequenced(before: DragGesture(minimumDistance: 0))
             .onChanged {

--- a/Sources/KeyboardKit/Gestures/KeyboardGestures.swift
+++ b/Sources/KeyboardKit/Gestures/KeyboardGestures.swift
@@ -134,7 +134,6 @@ private extension KeyboardGestures {
      maximumDistance: The maximum distance that the fingers or cursor performing the long press can move before the gesture fails.
      */
     var longPressGesture: some Gesture {
-        
         LongPressGesture(minimumDuration: 0.25, maximumDistance: 10)
             .onEnded { _ in handleLongPressGesture() }
     }
@@ -145,7 +144,6 @@ private extension KeyboardGestures {
      maximumDistance: The maximum distance that the fingers or cursor performing the long press can move before the gesture fails.
      */
     func longPressDragGesture(for geo: GeometryProxy) -> some Gesture {
-        
         LongPressGesture(minimumDuration: 0.25, maximumDistance: 10)
             .onEnded { _ in beginActionCallout(for: geo) }
             .sequenced(before: DragGesture(minimumDistance: 0))


### PR DESCRIPTION
Right now, the keyboard feels a bit slow when long pressing a button to see their secondary callouts. 

This PR introduces: 
overriding `minimumDuration` and `maximumDistance` and using 0.25 as a starting point. As a result, It feels 10x faster.