### PR TITLE
Feature/input view

### DIFF
--- a/Demo/Demo/Demo.xcodeproj/project.pbxproj
+++ b/Demo/Demo/Demo.xcodeproj/project.pbxproj
@@ -7,6 +7,7 @@
 	objects = {
 
 /* Begin PBXBuildFile section */
+		012C5F0029113179003D044C /* InputViewEditScreen.swift in Sources */ = {isa = PBXBuildFile; fileRef = 012C5EFF29113179003D044C /* InputViewEditScreen.swift */; };
 		A912D9D128C1E44E0007FAC1 /* KeyboardKit in Frameworks */ = {isa = PBXBuildFile; productRef = A912D9D028C1E44E0007FAC1 /* KeyboardKit */; };
 		A912D9D328C1E7F00007FAC1 /* DemoInputSetProvider.swift in Sources */ = {isa = PBXBuildFile; fileRef = A912D9D228C1E7F00007FAC1 /* DemoInputSetProvider.swift */; };
 		A912D9D528C1F0480007FAC1 /* CustomKeyboardLayoutProvider.swift in Sources */ = {isa = PBXBuildFile; fileRef = A912D9D428C1F0480007FAC1 /* CustomKeyboardLayoutProvider.swift */; };
@@ -110,6 +111,7 @@
 /* End PBXCopyFilesBuildPhase section */
 
 /* Begin PBXFileReference section */
+		012C5EFF29113179003D044C /* InputViewEditScreen.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = InputViewEditScreen.swift; sourceTree = "<group>"; };
 		A912D9D228C1E7F00007FAC1 /* DemoInputSetProvider.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DemoInputSetProvider.swift; sourceTree = "<group>"; };
 		A912D9D428C1F0480007FAC1 /* CustomKeyboardLayoutProvider.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CustomKeyboardLayoutProvider.swift; sourceTree = "<group>"; };
 		A921152225D58A94003510D9 /* Demo.app */ = {isa = PBXFileReference; explicitFileType = wrapper.application; includeInIndex = 0; path = Demo.app; sourceTree = BUILT_PRODUCTS_DIR; };
@@ -243,6 +245,7 @@
 				A921166125D5BC2A003510D9 /* EditScreen.swift */,
 				A99AE5C027183561004AD0A3 /* EnabledListItem.swift */,
 				A921152725D58A94003510D9 /* HomeScreen.swift */,
+				012C5EFF29113179003D044C /* InputViewEditScreen.swift */,
 				A921166625D5BC4F003510D9 /* MultilineTextField.swift */,
 			);
 			path = Demo;
@@ -564,6 +567,7 @@
 			isa = PBXSourcesBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
+				012C5F0029113179003D044C /* InputViewEditScreen.swift in Sources */,
 				A921166225D5BC2A003510D9 /* EditScreen.swift in Sources */,
 				A99AE5C127183561004AD0A3 /* EnabledListItem.swift in Sources */,
 				A921152825D58A94003510D9 /* HomeScreen.swift in Sources */,

--- a/Demo/Demo/Demo/EditScreen.swift
+++ b/Demo/Demo/Demo/EditScreen.swift
@@ -54,5 +54,6 @@ struct EditScreen_Previews: PreviewProvider {
 
     static var previews: some View {
         EditScreen(appearance: .default)
+            .environmentObject(KeyboardEnabledState(bundleId: Bundle.main.bundleIdentifier!))
     }
 }

--- a/Demo/Demo/Demo/HomeScreen.swift
+++ b/Demo/Demo/Demo/HomeScreen.swift
@@ -29,6 +29,9 @@ struct HomeScreen: View {
                     NavigationLink(destination: EditScreen(appearance: .dark)) {
                         Label("Type in a dark text field", image: .type)
                     }
+                    NavigationLink(destination: InputViewEditScreen(appearance: .default)) {
+                        Label("Type in a regular text field with keyboard as inputView", image: .type)
+                    }
                 }
                 Section(header: Text("Keyboard"), footer: footerText) {
                     EnabledListItem(

--- a/Demo/Demo/Demo/Info.plist
+++ b/Demo/Demo/Demo/Info.plist
@@ -33,7 +33,7 @@
 	<key>UIApplicationSceneManifest</key>
 	<dict>
 		<key>UIApplicationSupportsMultipleScenes</key>
-		<true/>
+		<false/>
 	</dict>
 	<key>UIApplicationSupportsIndirectInputEvents</key>
 	<true/>

--- a/Demo/Demo/Demo/InputViewEditScreen.swift
+++ b/Demo/Demo/Demo/InputViewEditScreen.swift
@@ -1,0 +1,84 @@
+//
+//  InputViewEditScreen.swift
+//  Demo
+//
+//  Created by Nick Brook on 01/11/2022.
+//  Copyright © 2022 Daniel Saidi. All rights reserved.
+//
+
+import SwiftUI
+import KeyboardKit
+
+struct CustomKeyboardView: View {
+    @EnvironmentObject
+    private var autocompleteContext: AutocompleteContext
+
+    @EnvironmentObject
+    private var keyboardContext: KeyboardContext
+    
+    var body: some View {
+        VStack(spacing: 0) {
+            if keyboardContext.keyboardType != .emojis {
+                autocompleteToolbar
+            }
+            SystemKeyboard()
+        }
+    }
+    var autocompleteToolbar: some View {
+        AutocompleteToolbar(
+            suggestions: autocompleteContext.suggestions,
+            locale: keyboardContext.locale
+        ).frame(height: 50)
+    }
+}
+
+class CustomKeyboardViewController: KeyboardInputViewController {
+    
+    override func viewDidLoad() {
+        super.viewDidLoad()
+        view.translatesAutoresizingMaskIntoConstraints = false
+    }
+    override func viewWillSetupKeyboard() {
+        super.viewWillSetupKeyboard()
+        setup(with: CustomKeyboardView())
+    }
+}
+
+/**
+ This screen has a multi-line text field that can be used to
+ try KeyboardKit with various keyboard appearance presets.
+ */
+struct InputViewEditScreen: View {
+    
+    let appearance: UIKeyboardAppearance
+    
+    @State
+    private var text = ""
+    
+    var body: some View {
+        List {
+            Section {
+                MultilineTextField(text: $text, appearance: appearance, configuration: {
+                    $0.inputView = CustomKeyboardViewController().view
+                    $0.reloadInputViews()
+                })
+                    .frame(height: 200)
+            }
+        }
+        .listStyle(.insetGrouped)
+        .navigationTitle(title)
+    }
+}
+
+private extension InputViewEditScreen {
+    var title: String {
+        appearance == .dark ? "Dark text field" : "Regular text field"
+    }
+}
+
+struct InputViewEditScreen_Previews: PreviewProvider {
+
+    static var previews: some View {
+        InputViewEditScreen(appearance: .default)
+    }
+}

--- a/Sources/KeyboardKit/Actions/KeyboardAction+Actions.swift
+++ b/Sources/KeyboardKit/Actions/KeyboardAction+Actions.swift
@@ -94,7 +94,7 @@ public extension KeyboardAction {
         if let action = standardTextDocumentProxyAction { return action }
         switch self {
         case .dismissKeyboard: return { $0?.dismissKeyboard() }
-        case .nextLocale: return { $0?.keyboardContext.selectNextLocale() }
+        case .nextKeyboard, .nextLocale: return { $0?.keyboardContext.selectNextLocale() }
         case .shift(let currentState): return {
             switch currentState {
             case .lowercased: $0?.keyboardContext.keyboardType = .alphabetic(.uppercased)

--- a/Sources/KeyboardKit/Gestures/View+KeyboardGestures.swift
+++ b/Sources/KeyboardKit/Gestures/View+KeyboardGestures.swift
@@ -27,7 +27,7 @@ public extension View {
         actionHandler: KeyboardActionHandler,
         isPressed: Binding<Bool> = .constant(false)
     ) -> some View {
-        if action == .nextKeyboard {
+        if action == .nextKeyboard && KeyboardContext.isAppExtension {
             self
         } else {
             withKeyboardGestures(for: action, isPressed: isPressed, actionHandler: actionHandler)

--- a/Sources/KeyboardKit/Keyboard/KeyboardContext.swift
+++ b/Sources/KeyboardKit/Keyboard/KeyboardContext.swift
@@ -98,12 +98,19 @@ public class KeyboardContext: ObservableObject {
         }
     }
     
-    public enum EmojiIncludeMode {
+    /// Used to specify when the emoji locale will be included
+    public enum EmojiIncludeStrategy {
+        /// The emoji locale will never be included
         case notIncluded
+        /// The emoji locale will be included if present in the active keyboards
         case includedIfActive
+        /// The emoji locale will always be included
         case included
     }
-    public lazy var includeEmojiInKeyboardLocales: EmojiIncludeMode = Self.isAppExtension ? .notIncluded : .includedIfActive
+    /// Determines when the emoji locale will be included in the keyboard locales
+    public lazy var includeEmojiInKeyboardLocales: EmojiIncludeStrategy = Self.isAppExtension ? .notIncluded : .includedIfActive
+    
+    /// A locale used as a placeholder for the emoji keyboard type
     private static let emojiLocale = Locale(identifier: "emoji")
 
     /**

--- a/Sources/KeyboardKit/Layout/Providers/iPhoneKeyboardLayoutProvider.swift
+++ b/Sources/KeyboardKit/Layout/Providers/iPhoneKeyboardLayoutProvider.swift
@@ -78,8 +78,8 @@ open class iPhoneKeyboardLayoutProvider: SystemKeyboardLayoutProvider {
         let needsInputSwitch = context.needsInputModeSwitchKey
         let needsDictation = context.needsInputModeSwitchKey
         if let action = keyboardSwitchActionForBottomRow(for: context) { result.append(action) }
-        if needsInputSwitch { result.append(.nextKeyboard) }
-        if !needsInputSwitch { result.append(.keyboardType(.emojis)) }
+        if needsInputSwitch || !KeyboardContext.isAppExtension { result.append(.nextKeyboard) }
+        else { result.append(.keyboardType(.emojis)) }
         if isPortrait(context), needsDictation, let action = dictationReplacement { result.append(action) }
         result.append(.space)
         if context.isAlphabetic(.persian) { result.append(.character(.zeroWidthSpace)) }

--- a/Sources/KeyboardKit/Locales/Locale+Localized.swift
+++ b/Sources/KeyboardKit/Locales/Locale+Localized.swift
@@ -14,6 +14,9 @@ public extension Locale {
      The localized name of the locale's identifier.
      */
     var localizedName: String {
+        guard self.identifier != "emoji" else {
+            return "Emoji"
+        }
         let text = localizedString(forIdentifier: identifier) ?? "-"
         return text.capitalized
     }

--- a/Sources/KeyboardKit/Locales/View+LocaleContextMenu.swift
+++ b/Sources/KeyboardKit/Locales/View+LocaleContextMenu.swift
@@ -23,7 +23,7 @@ public extension View {
         for context: KeyboardContext
     ) -> some View {
         self.localeContextMenu(for: context) { locale in
-            Text(locale.localizedName.capitalized)
+            Text(locale.localizedName)
         }
     }
     

--- a/Sources/KeyboardKit/Views/System/SystemKeyboardActionButtonContent.swift
+++ b/Sources/KeyboardKit/Views/System/SystemKeyboardActionButtonContent.swift
@@ -43,7 +43,11 @@ public struct SystemKeyboardActionButtonContent: View {
     public var body: some View {
         if action == .nextKeyboard {
             #if os(iOS) || os(tvOS)
-            NextKeyboardButton()
+            if KeyboardContext.isAppExtension {
+                NextKeyboardButton()
+            } else {
+                Image.keyboardGlobe
+            }
             #else
             Image.keyboardGlobe
             #endif

--- a/Sources/KeyboardKit/Views/System/SystemKeyboardButtonRowItem.swift
+++ b/Sources/KeyboardKit/Views/System/SystemKeyboardButtonRowItem.swift
@@ -92,7 +92,7 @@ public extension View {
     @ViewBuilder
     func localeContextMenu(for action: KeyboardAction, context: KeyboardContext) -> some View {
         #if os(iOS) || os(macOS) || os(watchOS)
-        if action == .nextLocale {
+        if action == .nextLocale || action == .nextKeyboard {
             self.localeContextMenu(for: context)
         } else {
             self


### PR DESCRIPTION
This PR adds an example of using KeyboardKit as an inputView, and improves KeyboardKit when used as an inputView. Notably, when used as an inputView:
* Will automatically mirror the active keyboards with the available locales in KeyboardKit
* Does not use the system `handleInputModeList(from:with:)` function on the globe button when not in an App extension
* Instead switches active KeyboardKit locales, and displays a picker which includes the emoji keyboard

Issues:
* No unit tests for modified functionality
* "Emoji" text not localised
* Method of determining if in an App Extension is not ideal, but I couldn't see another way. I didn't notice any properties of `UIInputViewController` that were different between App Extension and inputView for example.