### PR TITLE
Add originalTextDocumentProxy to keyboardContext

### DIFF
--- a/Sources/KeyboardKit/Keyboard/KeyboardContext.swift
+++ b/Sources/KeyboardKit/Keyboard/KeyboardContext.swift
@@ -149,6 +149,12 @@ public class KeyboardContext: ObservableObject {
     public var textDocumentProxy: UITextDocumentProxy = PreviewTextDocumentProxy()
     
     /**
+     The text document proxy that is currently active.
+     */
+    @Published
+    public var originalTextDocumentProxy: UITextDocumentProxy = PreviewTextDocumentProxy()
+    
+    /**
      The text input mode of the input controller.
      */
     @Published
@@ -313,6 +319,9 @@ public extension KeyboardContext {
         }
         if textDocumentProxy === controller.textDocumentProxy {} else {
             textDocumentProxy = controller.textDocumentProxy
+        }
+        if originalTextDocumentProxy === controller.originalTextDocumentProxy {} else {
+            originalTextDocumentProxy = controller.originalTextDocumentProxy
         }
         if textInputMode != controller.textInputMode {
             textInputMode = controller.textInputMode

--- a/Sources/KeyboardKit/KeyboardInputViewController.swift
+++ b/Sources/KeyboardKit/KeyboardInputViewController.swift
@@ -91,7 +91,7 @@ open class KeyboardInputViewController: UIInputViewController {
      which makes ``textDocumentProxy`` return the custom one
      instead of the original one.
      */
-    var originalTextDocumentProxy: UITextDocumentProxy {
+    open var originalTextDocumentProxy: UITextDocumentProxy {
         super.textDocumentProxy
     }
     

--- a/Sources/KeyboardKit/KeyboardInputViewController.swift
+++ b/Sources/KeyboardKit/KeyboardInputViewController.swift
@@ -17,7 +17,6 @@ import UIKit
  */
 open class KeyboardInputViewController: UIInputViewController {
     
-    
     // MARK: - View Controller Lifecycle
     
     open override func viewDidLoad() {
@@ -91,7 +90,7 @@ open class KeyboardInputViewController: UIInputViewController {
      which makes ``textDocumentProxy`` return the custom one
      instead of the original one.
      */
-    public var originalTextDocumentProxy: UITextDocumentProxy {
+    open var originalTextDocumentProxy: UITextDocumentProxy {
         super.textDocumentProxy
     }
     

--- a/Sources/KeyboardKit/KeyboardInputViewController.swift
+++ b/Sources/KeyboardKit/KeyboardInputViewController.swift
@@ -91,7 +91,7 @@ open class KeyboardInputViewController: UIInputViewController {
      which makes ``textDocumentProxy`` return the custom one
      instead of the original one.
      */
-    open var originalTextDocumentProxy: UITextDocumentProxy {
+    public var originalTextDocumentProxy: UITextDocumentProxy {
         super.textDocumentProxy
     }
     


### PR DESCRIPTION
Access the original text input while having an internal text input focused in KeyboardKit.