### PR TITLE
docs(autocomplete): Rename parameter `action` to `suggestionAction`

### DIFF
--- a/Sources/KeyboardKit/KeyboardKit.docc/Articles/Autocomplete.md
+++ b/Sources/KeyboardKit/KeyboardKit.docc/Articles/Autocomplete.md
@@ -134,7 +134,7 @@ private extension KeyboardView {
         AutocompleteToolbar(
             suggestions: autocompleteContext.suggestions,
             locale: keyboardContext.locale,
-            action: controller.insertAutocompleteSuggestion
+            suggestionAction: controller.insertAutocompleteSuggestion
         ).opacity(keyboardContext.prefersAutocomplete ? 1 : 0)  // Still allocate height to make room for callouts
     }
 }


### PR DESCRIPTION
It appears that the parameter `action` has been renamed to `suggestionAction` so the docs were outdated; this commit fixes that