### PR TITLE
Disable captureTextFromCamera in KeyboardInputTextField

### DIFF
--- a/Sources/KeyboardKit/Routing/KeyboardTextField.swift
+++ b/Sources/KeyboardKit/Routing/KeyboardTextField.swift
@@ -181,5 +181,21 @@ class KeyboardInputTextField: UITextField, KeyboardInputComponent {
         handleResignFirstResponder()
         return super.resignFirstResponder()
     }
+
+  /// Requests the receiving responder to enable or disable the specified command in the user interface.
+  ///
+  /// We've overriden `canPerformAction` to disable the `captureTextFromCamera` action as a workaround
+  /// for a `NSInternalInconsistencyException`:
+  ///
+  /// ```
+  /// Keyboard Camera is being used without remote keyboards enabled.
+  /// ```
+  override func canPerformAction(_ action: Selector, withSender sender: Any?) -> Bool {
+    if #available(iOS 15.0, *) {
+      return action == #selector(captureTextFromCamera) ? false : super.canPerformAction(action, withSender: sender)
+    } else {
+      return super.canPerformAction(action, withSender: sender)
+    }
+  }
 }
 #endif


### PR DESCRIPTION
This fixes a crash caused by custom keyboards not being able to support camera input in text fields. I brought this particular fix over from a personal project before I migrated it over to `KeyboardKit`. I found the fix [here](https://developer.apple.com/forums/thread/698003), I'm not aware of any other alternatives.

https://user-images.githubusercontent.com/6403910/233868022-86483214-b74c-4464-8080-cea8f5134331.mov