### PR TITLE
Preventive Check Before View Removal to Avoid Unexpected Crashes

### DIFF
--- a/Sources/KeyboardKit/Keyboard/KeyboardHostingController.swift
+++ b/Sources/KeyboardKit/Keyboard/KeyboardHostingController.swift
@@ -40,7 +40,9 @@ public class KeyboardHostingController<Content: View>: UIHostingController<Conte
 
     deinit {
         removeFromParent()
-        view.removeFromSuperview()
+        if view.superview != nil {
+            view.removeFromSuperview()
+        }
     }
     
     public override func viewWillLayoutSubviews() {


### PR DESCRIPTION
In the current implementation of `KeyboardHostingController`, the method `view.removeFromSuperview()` is called without checking if the view is already a subview of another view. This can lead to unexpected crashes if the view is not part of any view hierarchy when this method is invoked.

To enhance the stability of the library and prevent potential crashes, a conditional check is introduced before removing the view from its superview. By ensuring that the view has a superview before attempting to remove it, we can avoid unnecessary crashes and make the library more robust.

This modification is particularly important for scenarios where the `KeyboardHostingController` might be invoked multiple times in quick succession, or in cases where the view hierarchy might change dynamically. By adding this simple check, we can ensure a smoother user experience and reduce the likelihood of runtime errors.