### PR TITLE
Add  Simplified Chinese support

### DIFF
--- a/Sources/KeyboardKit/Resources/zh-Hans.lproj/Localizable.strings
+++ b/Sources/KeyboardKit/Resources/zh-Hans.lproj/Localizable.strings
@@ -1,0 +1,28 @@
+/*
+ Localizable.strings
+ KeyboardKit
+ 
+ Created by Kevin Ren on 2023-11-12.
+ Copyright © 2023 Kevin Ren. All rights reserved.
+ */
+
+"locale" = "zh-Hans";
+
+"continue" = "继续";
+"done" = "完成";
+"emergencyCall" = "紧急呼叫";
+"go" = "前往";
+"join" = "加入";
+"next" = "下一个";
+"ok" = "好";
+"return" = "返回";
+"route" = "路线";
+"search" = "搜索";
+"send" = "发送";
+"space" = "空格";
+
+"keyboardTypeAlphabetic" = "ABC";
+"keyboardTypeNumeric" = "123";
+"keyboardTypeSymbolic" = "#+=";
+
+"searchEmoji" = "搜索表情符号";


### PR DESCRIPTION
Hi there, thanks for your great work, I am using KeyboardKit to build my Keyboard App.
However my App is designed for Chinese text input, so I added a `Localizable.strings` file for `zh-Hans`(Simplified Chinese). It's fixed some system buttons do not have titles when setting local to `zh-Hans`. 