### PR TITLE
Supports configuration of the symbol to be inserted when a sentence ends

### DIFF
--- a/Sources/KeyboardKit/Actions/KeyboardAction+StandardHandler.swift
+++ b/Sources/KeyboardKit/Actions/KeyboardAction+StandardHandler.swift
@@ -329,7 +329,7 @@ extension KeyboardAction {
             on action: KeyboardAction
         ) {
             guard keyboardBehavior.shouldEndSentence(after: gesture, on: action) else { return }
-            keyboardContext.endSentence()
+            keyboardContext.endSentence(symbolic: keyboardBehavior.endSentenceSymbolic)
         }
         
         /// Try to perform autocomplete after a gesture.

--- a/Sources/KeyboardKit/Proxy/UITextDocumentProxy+Sentences.swift
+++ b/Sources/KeyboardKit/Proxy/UITextDocumentProxy+Sentences.swift
@@ -37,12 +37,12 @@ public extension UITextDocumentProxy {
 
     /// End the current sentence by removing trailing spaces,
     /// then injecting a dot and a space.
-    func endSentence() {
+    func endSentence(symbolic: String) {
         guard isCursorAtTheEndOfTheCurrentWord else { return }
         while (documentContextBeforeInput ?? "").hasSuffix(" ") {
             deleteBackward(times: 1)
         }
-        insertText(". ")
+        insertText(symbolic)
     }
 }
 #endif

--- a/Sources/KeyboardKit/_Essentials/Keyboard+StandardBehavior.swift
+++ b/Sources/KeyboardKit/_Essentials/Keyboard+StandardBehavior.swift
@@ -35,12 +35,14 @@ extension Keyboard {
             keyboardContext: KeyboardContext,
             doubleTapThreshold: TimeInterval = 0.5,
             endSentenceThreshold: TimeInterval = 3.0,
-            repeatGestureTimer: Gestures.RepeatTimer = .shared
+            repeatGestureTimer: Gestures.RepeatTimer = .shared,
+            endSentenceSymbolic: String = ". "
         ) {
             self.keyboardContext = keyboardContext
             self.doubleTapThreshold = doubleTapThreshold
             self.endSentenceThreshold = endSentenceThreshold
             self.repeatGestureTimer = repeatGestureTimer
+            self.endSentenceSymbolic = endSentenceSymbolic
         }
         
         
@@ -71,6 +73,9 @@ extension Keyboard {
             let duration = repeatGestureTimer.duration ?? 0
             return duration > 3 ? .word : .character
         }
+        
+        /// The  symbolic that  end the sentence after a gesture action should  inject.
+        public var endSentenceSymbolic: String
         
         /// The preferred keyboard type after an action gesture.
         open func preferredKeyboardType(

--- a/Sources/KeyboardKit/_Essentials/KeyboardBehavior.swift
+++ b/Sources/KeyboardKit/_Essentials/KeyboardBehavior.swift
@@ -27,6 +27,9 @@ public protocol KeyboardBehavior {
     /// The range that backspace should delete.
     var backspaceRange: Keyboard.BackspaceRange { get }
     
+    /// The  symbolic that  end the sentence after a gesture action should  inject.
+    var endSentenceSymbolic: String { get set }
+    
     /// The preferred keyboard type after an action gesture.
     func preferredKeyboardType(
         after gesture: Gesture,

--- a/Sources/KeyboardKit/_Essentials/KeyboardContext+ProxyBridging.swift
+++ b/Sources/KeyboardKit/_Essentials/KeyboardContext+ProxyBridging.swift
@@ -15,9 +15,9 @@ import Foundation
 /// e.g. macOS and watchOS, make sure to replace them later.
 extension KeyboardContext {
     
-    func endSentence() {
+    func endSentence(symbolic: String) {
         #if os(iOS) || os(tvOS) || os(visionOS)
-        textDocumentProxy.endSentence()
+        textDocumentProxy.endSentence(symbolic: symbolic)
         #endif
     }
     


### PR DESCRIPTION
Supports configuration of the symbol to be inserted when a sentence ends.For example, in Chinese input method, the sentence end should be inserted as 。 instead of .
So it is important to support the symbols inserted at the end of the custom configuration.