### PR TITLE
Replay PR #374: Support for embedding as UIInputViewController directly in app

### DIFF
--- a/Sources/KeyboardKit/Host/KeyboardInputViewController+Host.swift
+++ b/Sources/KeyboardKit/Host/KeyboardInputViewController+Host.swift
@@ -12,15 +12,21 @@ import UIKit
 
 public extension KeyboardInputViewController {
     
-    /// The bundle ID of the host application, if any.
+    /// The bundle ID of the host application, if any, or if the view
+    /// is instantiated directly within a host app, the bundle id
+    /// of the main bundle.
     ///
     /// The property uses technologies that may stop working
     /// in any future iOS version. Do not rely solely on the
     /// function, and design the app to be able to work even
     /// if this feature suddenly stops working.
     var hostApplicationBundleId: String? {
-        if let id = hostBundleIdValueBefore16 { return id }
-        return hostBundleIdValueFor16
+        if Bundle.main.isExtension {
+            if let id = hostBundleIdValueBefore16 { return id }
+            return hostBundleIdValueFor16
+        } else {
+            return Bundle.main.bundleIdentifier
+        }
     }
     
     @available(*, deprecated, renamed: "hostApplicationBundleId")


### PR DESCRIPTION
PR #374 was merged, but was rolled back accidentally.

Protect against an undefined key error when instantiating the KeyboardInputViewController in an app, where the parent will not implement the private `_hostBundleID` property.
