### PR TITLE
Fix demo app's keyboard menu button shape on iOS26

### DIFF
--- a/Demo/Keyboard/DemoKeyboardMenu.swift
+++ b/Demo/Keyboard/DemoKeyboardMenu.swift
@@ -156,7 +156,15 @@ extension DemoKeyboardMenu {
         .buttonStyle(.bordered)
         .tint(tint.gradient)
         .background(Color.primary.colorInvert())
-        .clipShape(.rect(cornerRadius: 20))
+        .modify { content in
+            if #available(iOS 26, *) {
+                content
+                    .clipShape(.capsule)
+            } else {
+                content
+                    .clipShape(.rect(cornerRadius: 20))
+            }
+        }
         .shadow(color: .black.opacity(0.3), radius: 0, x: 0, y: 1)
     }
 
@@ -174,6 +182,12 @@ private extension DemoKeyboardMenu {
     func tryOpenUrl(_ url: String?) {
         guard let url, let url = URL(string: url) else { return }
         actionHandler.handle(.url(url))
+    }
+}
+
+public extension View {
+    func modify(@ViewBuilder transform: (Self) -> some View) -> some View {
+        transform(self)
     }
 }
 


### PR DESCRIPTION
See issue https://github.com/KeyboardKit/KeyboardKit/issues/982

If it's desired that the buttons adapt to the OS .bordered button shape, this is one way to accomplish that.

After this change, this is what the demo app's keyboard menu looks like on 18.6 and 26.1. 

### iOS 18.6
<img width="1170" height="2532" alt="Simulator Screenshot - iPhone 16e - 2025-11-28 at 19 59 22" src="https://github.com/user-attachments/assets/aaf79cd3-28b4-437d-8f03-35f80d5e7613" />

### iOS 26.1
<img width="1206" height="2622" alt="Simulator Screenshot - iPhone 17 Pro - 2025-11-28 at 19 57 54" src="https://github.com/user-attachments/assets/508109d9-b173-4d23-b879-9e56e99cabc3" />

